### PR TITLE
[0.2.0] Update development dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ spec/dummy/tmp/
 coverage
 .idea
 node_modules/
+
+*.gem

--- a/pugin.gemspec
+++ b/pugin.gemspec
@@ -12,20 +12,20 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/ukparliament/pugin'
   s.summary     = 'Pugin is a component-based pattern design library for UK Parliament microservices.'
   s.description = 'Pugin is a component-based pattern design library that holds all of the reusable partials, styles and scripts for elements of UK Parliament microservices.'
-  s.license     = 'Open Parliament License'
+  s.license     = 'Nonstandard'
 
   s.files = Dir["{app,config,db,lib}/**/*", 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '~> 5.0.1'
+  s.add_dependency 'rails', '~> 5.0'
   s.add_dependency 'haml', '~> 4.0'
 
-  s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'capybara'
-  s.add_development_dependency 'factory_girl_rails'
-  s.add_development_dependency 'simplecov'
-  s.add_development_dependency 'coveralls'
-  s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'pry'
+  s.add_development_dependency 'sqlite3', '~> 1.3'
+  s.add_development_dependency 'rspec-rails', '~> 3.5'
+  s.add_development_dependency 'capybara', '~> 2.12'
+  s.add_development_dependency 'factory_girl_rails', '~> 4.8'
+  s.add_development_dependency 'simplecov', '~> 0.12'
+  s.add_development_dependency 'coveralls', '~> 0.8'
+  s.add_development_dependency 'rubocop', '~> 0.47'
+  s.add_development_dependency 'pry', '~> 0.10'
 end


### PR DESCRIPTION
In order to release the 0.2.0 version of the gem, we needed to update the development dependencies to include versions.