### PR TITLE
[WEBSITE-931] Updated header/footer/status banner

### DIFF
--- a/app/views/pugin/components/_footer.html.haml
+++ b/app/views/pugin/components/_footer.html.haml
@@ -1,11 +1,8 @@
 %footer
-  .container--full-screen.footer
-    .container--full-grid
-      .row--indent-horizontal
-        .footer__logo
-          %p= t('.parliament_uk')
-        %ul.footer__list
-          %li
-            %a{:href => "https://www.parliament.uk/"}= t('.current_website')
-          %li
-            %a{:href => "/meta/cookie-policy"}= t('.cookie_policy')
+  .container--full-grid
+    %h2.logo= t('.uk_parliament')
+    %ul.list
+      %li
+        %a{:href => "https://www.parliament.uk/"}= t('.current_website')
+      %li
+        %a{:href => "http://beta.parliament.uk/meta/cookie-policy"}= t('.cookie_policy')

--- a/app/views/pugin/components/_header.html.haml
+++ b/app/views/pugin/components/_header.html.haml
@@ -1,6 +1,3 @@
 %header
-  .container--full-screen.header
-    .container--full-grid
-      .row--indent-horizontal
-        .header__logo
-          %a{:href => "/"}= t('.parliament_header')
+  .container--full-grid
+    %a.logo{:href => "/"}= t('.parliament_header')

--- a/app/views/pugin/components/_status.html.haml
+++ b/app/views/pugin/components/_status.html.haml
@@ -1,5 +1,3 @@
-.highlight__status
-  %div{class: "container--full-screen status#{ status.nil? ? '' : "__#{status}"  }"}
-    .container--full-grid
-      .row--indent-horizontal
-        %p #{t('.status_text_1')} - #{link_to t('.give_feedback'), 'https://ukparliament-self.achieveservice.com/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-032e1b1d-958f-4402-9ab2-97a38ed9b899/AF-Stage9b7ecae8-0c85-4ee7-afda-b256cffe5f08/definition.json&redirectlink=%2F&cancelRedirectLink=%2F&category=AF-Category-48936b5c-9329-48c7-a0a5-563463aacadf', target: '_blank', title: t('open_new_window')} #{t('.status_text_2')} #{link_to t('.current_website'), 'https://www.parliament.uk'}.
+.highlight__status{class: "status#{ status.nil? ? '' : "__#{status}"  }"}
+  .container--full-grid
+    %p #{t('.status_text_1')} - #{link_to t('.give_feedback'), 'https://ukparliament-self.achieveservice.com/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-032e1b1d-958f-4402-9ab2-97a38ed9b899/AF-Stage9b7ecae8-0c85-4ee7-afda-b256cffe5f08/definition.json&redirectlink=%2F&cancelRedirectLink=%2F&category=AF-Category-48936b5c-9329-48c7-a0a5-563463aacadf', target: '_blank', title: t('open_new_window')} #{t('.status_text_2')} #{link_to t('.current_website'), 'https://www.parliament.uk'}.

--- a/app/views/pugin/layouts/pugin.html.haml
+++ b/app/views/pugin/layouts/pugin.html.haml
@@ -16,7 +16,6 @@
     = render partial: 'pugin/components/status', locals: { status: nil }
     %main#content
       .container--full-grid
-        .row--indent-full
-          = yield
+        = yield
     = render 'pugin/components/footer'
     %script{src: "#{ENV['ASSET_LOCATION_URL']}/#{Pugin::ASSET_VERSION}/javascripts/main.js"}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,7 +12,7 @@ en:
         status_text_2: 'to help improve it. Return to'
         give_feedback: 'give feedback'
       footer: 
-        parliament_uk: "Parliament.uk"
+        uk_parliament: "UK Parliament"
         current_website: "Current Parliament.uk website"
         cookie_policy: "Cookie Policy"
     layouts: 

--- a/lib/pugin/version.rb
+++ b/lib/pugin/version.rb
@@ -1,4 +1,4 @@
 module Pugin
   VERSION = '0.5.1'.freeze
-  ASSET_VERSION = '1.2.6'.freeze
+  ASSET_VERSION = '1.2.7'.freeze
 end

--- a/spec/views/pugin/components/_footer.html.haml_spec.rb
+++ b/spec/views/pugin/components/_footer.html.haml_spec.rb
@@ -8,22 +8,16 @@ describe 'pugin/components/_footer.html.haml', type: :view do
 
     expect(response).to eq(<<DATA
 <footer>
-<div class='container--full-screen footer'>
 <div class='container--full-grid'>
-<div class='row--indent-horizontal'>
-<div class='footer__logo'>
-<p>Parliament.uk</p>
-</div>
-<ul class='footer__list'>
+<h2 class='logo'>UK Parliament</h2>
+<ul class='list'>
 <li>
 <a href='https://www.parliament.uk/'>Current Parliament.uk website</a>
 </li>
 <li>
-<a href='/meta/cookie-policy'>Cookie Policy</a>
+<a href='http://beta.parliament.uk/meta/cookie-policy'>Cookie Policy</a>
 </li>
 </ul>
-</div>
-</div>
 </div>
 </footer>
 DATA

--- a/spec/views/pugin/components/_header.html.haml_spec.rb
+++ b/spec/views/pugin/components/_header.html.haml_spec.rb
@@ -8,14 +8,8 @@ describe 'pugin/components/_header.html.haml', type: :view do
 
     expect(response).to eq(<<DATA
 <header>
-<div class='container--full-screen header'>
 <div class='container--full-grid'>
-<div class='row--indent-horizontal'>
-<div class='header__logo'>
-<a href='/'>UK Parliament</a>
-</div>
-</div>
-</div>
+<a class='logo' href='/'>UK Parliament</a>
 </div>
 </header>
 DATA

--- a/spec/views/pugin/components/_status.html.haml_spec.rb
+++ b/spec/views/pugin/components/_status.html.haml_spec.rb
@@ -9,13 +9,9 @@ describe 'pugin/components/_status.html.haml', type: :view do
 
       expect(response).to eq(
 <<DATA
-<div class='highlight__status'>
-<div class='container--full-screen status'>
+<div class='highlight__status status'>
 <div class='container--full-grid'>
-<div class='row--indent-horizontal'>
 <p>This is a test website, so may be inaccurate or misleading - <a target="_blank" title="website opens in a new window" href="https://ukparliament-self.achieveservice.com/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-032e1b1d-958f-4402-9ab2-97a38ed9b899/AF-Stage9b7ecae8-0c85-4ee7-afda-b256cffe5f08/definition.json&amp;redirectlink=%2F&amp;cancelRedirectLink=%2F&amp;category=AF-Category-48936b5c-9329-48c7-a0a5-563463aacadf">give feedback</a> to help improve it. Return to <a href="https://www.parliament.uk">current website</a>.</p>
-</div>
-</div>
 </div>
 </div>
 DATA
@@ -29,13 +25,9 @@ DATA
 
       expect(rendered).to eq(
 <<DATA
-<div class='highlight__status'>
-<div class='container--full-screen status__test'>
+<div class='highlight__status status__test'>
 <div class='container--full-grid'>
-<div class='row--indent-horizontal'>
 <p>This is a test website, so may be inaccurate or misleading - <a target="_blank" title="website opens in a new window" href="https://ukparliament-self.achieveservice.com/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-032e1b1d-958f-4402-9ab2-97a38ed9b899/AF-Stage9b7ecae8-0c85-4ee7-afda-b256cffe5f08/definition.json&amp;redirectlink=%2F&amp;cancelRedirectLink=%2F&amp;category=AF-Category-48936b5c-9329-48c7-a0a5-563463aacadf">give feedback</a> to help improve it. Return to <a href="https://www.parliament.uk">current website</a>.</p>
-</div>
-</div>
 </div>
 </div>
 DATA


### PR DESCRIPTION
* Included release 1.2.7 of parliament.uk-pugin
* Refactored header
* Refactored footer
* Refactored status banner
* Updated tests for header/footer/status banner
* Updated footer logo text
* Added full path to cookie policy