### PR TITLE
[WEBSITE-1293][WEBSITE-1294][WEBSITE-1295][WEBSITE-1265][WEBSITE-1280] Dissolution Message Updates and A-Z navigation fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pugin (0.7.1)
+    pugin (0.8.1)
 
 GEM
   remote: https://rubygems.org/

--- a/app/views/pugin/components/_navigation-letter.haml
+++ b/app/views/pugin/components/_navigation-letter.haml
@@ -8,7 +8,7 @@
         %li{ data: { letter: letter }, class: ('active' if (params[:letter] == letter)) }
           - if @letters.include?(letter.upcase)
             - unless letter == params[:letter]
-              = navigation_link(route_symbol: route_symbol, letter: letter, primary_id: local_assigns.fetch(:primary_id, nil), secondary_id: local_assigns.fetch(:secondary_id, nil))
+              = navigation_link(route_symbol: route_symbol, route_args: local_assigns.fetch(:route_args, []), letter: letter)
             - else
               %span= letter
           - else

--- a/app/views/pugin/components/_status.haml
+++ b/app/views/pugin/components/_status.haml
@@ -12,4 +12,8 @@
           = I18n.t('pugin.components.status.election_text_2')
           %a{ href: 'http://www.parliament.uk/get-involved/elections/voting/', target: '_blank', title: I18n.t('open_new_window')}= I18n.t('pugin.components.status.how_to_vote')
           = I18n.t('pugin.components.status.election_text_3')
- 
+      - elsif Pugin::Feature::Bandiera.election?
+        = I18n.t('pugin.components.status.election_day_text')
+        = succeed "." do
+          %a{ href: 'http://www.parliament.uk/get-involved/elections/voting/', target: '_blank', title: I18n.t('open_new_window')}= I18n.t('pugin.components.status.how_to_vote')
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,6 +12,7 @@ en:
         election_text_1: 'in the general election by 22 May.'
         election_text_2: 'Find out'
         election_text_3: 'in the general election on 8 June.'
+        election_day_text: 'Thursday 8 June is election day, find out'
         give_feedback: 'Give feedback'
         register_to_vote: 'Register to vote'
         how_to_vote: 'how to vote'

--- a/lib/pugin/feature/bandiera.rb
+++ b/lib/pugin/feature/bandiera.rb
@@ -12,6 +12,16 @@ module Pugin
 
 					@features.fetch('show-register', false)
 				end
+				def election?
+					get_features
+
+					@features.fetch('show-election', false)
+				end
+				def post_election?
+					get_features
+
+					@features.fetch('show-post-election', false)
+				end
 
 				# Reset cached features
 				def reset

--- a/lib/pugin/version.rb
+++ b/lib/pugin/version.rb
@@ -1,3 +1,3 @@
 module Pugin
-  VERSION = '0.7.1'.freeze
+  VERSION = '0.8.1'.freeze
 end

--- a/lib/pugin/view_helpers.rb
+++ b/lib/pugin/view_helpers.rb
@@ -1,8 +1,7 @@
 module Pugin
 	module ViewHelpers
-		def navigation_link(route_symbol:, letter:, primary_id: nil, secondary_id: nil)
-			url = send(route_symbol, primary_id, secondary_id, letter) if primary_id && secondary_id
-			url = send(route_symbol, primary_id, letter) if primary_id && secondary_id.nil?
+		def navigation_link(route_symbol:, route_args:, letter:)
+			url = send(route_symbol, *route_args, letter) unless route_args.empty?
 			url = send(route_symbol, letter) unless url
 
 			return link_to(letter, url, data: { 'atoz-see': 'true' })

--- a/spec/lib/pugin/feature/bandiera_spec.rb
+++ b/spec/lib/pugin/feature/bandiera_spec.rb
@@ -1,52 +1,34 @@
 require 'spec_helper'
 require 'pugin/feature/bandiera'
 
-describe 'The bandiera client' do
+describe 'The bandiera client feature set' do
 
-    context 'when checking if Parliament is in dissolution' do 
-        context 'when the feature exists in Bandiera' do
+    method_hash = {
+        'show-dissolution': :dissolution?,
+        'show-register': :register_to_vote?,
+        'show-election': :election?,
+        'show-post-election': :post_election?
+    }
 
-            before :each do
-                Pugin::Feature::Bandiera.instance_variable_set(:@features, {'show-dissolution' => true})
+    method_hash.each do |flag_name, method_name|
+        context flag_name do
+            context 'when the feature exists in Bandiera' do
+                before :each do
+                    Pugin::Feature::Bandiera.instance_variable_set(:@features, {"#{flag_name}" => true})
+                end
+
+                it "returns the value of #{flag_name} in the Bandiera database if it exists" do
+                    expect(Pugin::Feature::Bandiera.send(method_name)).to equal(true)
+                end
             end
+            context 'when the feature does not exist in Bandiera' do
+                before :each do
+                    Pugin::Feature::Bandiera.instance_variable_set(:@features, {})
+                end
 
-            it "returns the value of show-dissolution in the Bandiera database if it exists"  do 
-                expect(Pugin::Feature::Bandiera.dissolution?).to equal(true)
-            end
-        end
-
-        context 'when the feature does not exist in Bandiera' do 
-
-            before :each do
-                Pugin::Feature::Bandiera.instance_variable_set(:@features, {})
-            end
-
-            it "returns false because the feature value is nil"  do 
-                expect(Pugin::Feature::Bandiera.dissolution?).to equal(false)
-            end
-        end
-    end
-
-    context 'when checking if you can still register to vote' do 
-        context 'when the feature exists in Bandiera' do 
-
-            before :each do
-                Pugin::Feature::Bandiera.instance_variable_set(:@features, {'show-register' => true})
-            end
-
-            it "returns the value of show-dissolution in the Bandiera database if it exists"  do 
-                expect(Pugin::Feature::Bandiera.register_to_vote?).to equal(true)
-            end
-        end
-
-        context 'when the feature does not exist in Bandiera' do 
-
-            before :each do
-                Pugin::Feature::Bandiera.instance_variable_set(:@features, {})
-            end
-
-            it "returns false because the feature value is nil"  do 
-                expect(Pugin::Feature::Bandiera.register_to_vote?).to equal(false)
+                it "returns false because the feature value is nil"  do
+                    expect(Pugin::Feature::Bandiera.send(method_name)).to equal(false)
+                end
             end
         end
     end

--- a/spec/views/pugin/components/_navigation-letter.html.haml_spec.rb
+++ b/spec/views/pugin/components/_navigation-letter.html.haml_spec.rb
@@ -51,23 +51,11 @@ describe 'pugin/components/_navigation-letter.html.haml', type: :view do
       end
     end
 
-    # Test for primary id and letter
-    context 'and a primary id' do
-      before :each do
-        render partial: 'pugin/components/navigation-letter', locals: { route_symbol: :party_members_letter_path, primary_id: @primary_id }
+    context 'and with route arguments' do 
+      before :each do 
+        render partial: 'pugin/components/navigation-letter', locals: { route_symbol: :house_party_members_letter_path, route_args:[@primary_id,@secondary_id] }
       end
 
-      ('a'..'z').each do |letter|
-        it "renders a navigation link for /parties/1234/a-z/#{letter}" do
-          expect(rendered).to include("<a data-atoz-see=\"true\" href=\"/parties/1234/members/a-z/#{letter}\">#{letter}</a>")
-        end
-      end
-    end
-
-    context 'and both a primary and secondary id' do
-      before :each do
-        render partial: 'pugin/components/navigation-letter', locals: { route_symbol: :house_party_members_letter_path, primary_id: @primary_id, secondary_id: @secondary_id }
-      end
       ('a'..'z').each do |letter|
         it "renders a navigation link for /houses/1234/parties/5678/members/a-z/#{letter}" do
           expect(rendered).to include("<a data-atoz-see=\"true\" href=\"/houses/1234/parties/5678/members/a-z/#{letter}\">#{letter}</a>")
@@ -78,7 +66,7 @@ describe 'pugin/components/_navigation-letter.html.haml', type: :view do
     context "doesn't render links for empty letters" do
       before :each do
         @letters = []
-        render partial: 'pugin/components/navigation-letter', locals: { route_symbol: :party_members_letter_path, primary_id: @primary_id }
+        render partial: 'pugin/components/navigation-letter', locals: { route_symbol: :party_members_letter_path, route_args: [@primary_id] }
       end
 
       ('a'..'z').each do |letter|

--- a/spec/views/pugin/components/_status.html.haml_spec.rb
+++ b/spec/views/pugin/components/_status.html.haml_spec.rb
@@ -8,6 +8,7 @@ describe 'pugin/components/_status.html.haml', type: :view do
   	before :each do 
       allow(Pugin::Feature::Bandiera).to receive(:dissolution?).and_return(false)
       allow(Pugin::Feature::Bandiera).to receive(:register_to_vote?).and_return(false)
+      allow(Pugin::Feature::Bandiera).to receive(:election?).and_return(false)
     end
 
     it 'renders a message not related to the dissolution' do
@@ -84,5 +85,35 @@ DATA
       )
     end
   end
+
+  context 'while on election day' do
+
+    before :each do
+      allow(Pugin::Feature::Bandiera).to receive(:dissolution?).and_return(false)
+      allow(Pugin::Feature::Bandiera).to receive(:register_to_vote?).and_return(false)
+      allow(Pugin::Feature::Bandiera).to receive(:election?).and_return(true)
+    end
+
+    it 'renders a message that reminds the user of the general election date' do
+      render partial: 'pugin/components/status', locals: { status: nil }
+
+      expect(response).to eq(
+<<DATA
+<div class='highlight--status highlight--default'>
+<div class='container'>
+<p>
+This is a test website, so may be inaccurate.
+<a href='http://www.smartsurvey.co.uk/s/ukparliament-beta-website-feedback/' target='_blank' title='website opens in a new window'>Give feedback</a>
+to help improve it.
+Thursday 8 June is election day, find out
+<a href='http://www.parliament.uk/get-involved/elections/voting/' target='_blank' title='website opens in a new window'>how to vote</a>.
+</p>
+</div>
+</div>
+DATA
+      )
+    end
+  end
+
 
 end


### PR DESCRIPTION
- Updated navigation letter component to accept 'n' arguments for according route path
- Updated status banner to work correctly on election day
- Added new bandiera features for election day and post-election
- Optimised Bandiera and other tests
- Bumped version number ready for release